### PR TITLE
Add processable resource provider

### DIFF
--- a/src/Provider/ProcessableResourceProvider.php
+++ b/src/Provider/ProcessableResourceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusImagePlugin\Provider;
+
+use Setono\SyliusImagePlugin\Model\ImageInterface;
+
+final class ProcessableResourceProvider implements ProcessableResourceProviderInterface
+{
+    /** @var array<string, array{classes: array{model: class-string}}> */
+    private array $resources;
+
+    /**
+     * @param array<string, array{classes: array{model: class-string}}> $resources
+     */
+    public function __construct(array $resources)
+    {
+        $this->resources = $resources;
+    }
+
+    public function getResources(): array
+    {
+        $processableResources = [];
+
+        foreach ($this->resources as $resource) {
+            if (!is_a($resource['classes']['model'], ImageInterface::class, true)) {
+                continue;
+            }
+
+            $processableResources[] = $resource['classes']['model'];
+        }
+
+        return $processableResources;
+    }
+}

--- a/src/Provider/ProcessableResourceProviderInterface.php
+++ b/src/Provider/ProcessableResourceProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusImagePlugin\Provider;
+
+interface ProcessableResourceProviderInterface
+{
+    /**
+     * Will return an array of resource class strings that are able to be processed
+     *
+     * @return list<class-string>
+     */
+    public function getResources(): array;
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,7 @@
         <import resource="services/controller.xml"/>
         <import resource="services/event_subscriber.xml"/>
         <import resource="services/message.xml"/>
+        <import resource="services/provider.xml"/>
         <import resource="services/synchronizer.xml"/>
         <import resource="services/twig.xml"/>
         <import resource="services/variant_generator.xml"/>

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -12,12 +12,12 @@
         <service id="setono_sylius_image.command.process"
                  class="Setono\SyliusImagePlugin\Command\ProcessCommand">
             <argument type="service" id="doctrine"/>
+            <argument type="service" id="setono_sylius_image.provider.processable_resource"/>
             <argument type="service" id="setono_sylius_image.command_bus"/>
             <argument type="service" id="setono_sylius_image.config.variant_collection"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="setono_sylius_image.repository.variant_configuration"/>
             <argument type="service" id="setono_sylius_image.synchronizer.variant_configuration"/>
-            <argument>%sylius.resources%</argument>
 
             <tag name="console.command"/>
         </service>
@@ -32,8 +32,8 @@
         <service id="setono_sylius_image.command.timeout"
                  class="Setono\SyliusImagePlugin\Command\TimeoutCommand">
             <argument type="service" id="doctrine"/>
+            <argument type="service" id="setono_sylius_image.provider.processable_resource"/>
             <argument type="service" id="workflow.registry"/>
-            <argument>%sylius.resources%</argument>
             <argument>%setono_sylius_image.timeout_threshold%</argument>
 
             <tag name="console.command"/>

--- a/src/Resources/config/services/provider.xml
+++ b/src/Resources/config/services/provider.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="setono_sylius_image.provider.processable_resource"
+                 class="Setono\SyliusImagePlugin\Provider\ProcessableResourceProvider">
+            <argument>%sylius.resources%</argument>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
This PR adds a provider for processable resources. This makes it easier for plugin users to controls which resources to process if they don't want to use the default way of deducing this.