### PR TITLE
27 add initial processing state

### DIFF
--- a/src/Command/ProcessCommand.php
+++ b/src/Command/ProcessCommand.php
@@ -235,7 +235,7 @@ EOF, self::OPTION_SYNC_CONFIGURATION, SynchronizeVariantConfigurationCommand::ge
             ->setParameter('variantConfiguration', $variantConfiguration)
             ->setParameter('now', $now)
             ->setParameter('maximumNumberOfTries', $this->maximumNumberOfTries)
-            ->setParameter('processingStates', [ImageInterface::PROCESSING_STATE_PENDING, ImageInterface::PROCESSING_STATE_FAILED])
+            ->setParameter('processingStates', [ImageInterface::PROCESSING_STATE_INITIAL, ImageInterface::PROCESSING_STATE_FAILED, ImageInterface::PROCESSING_STATE_PROCESSED])
         ;
 
         do {

--- a/src/Command/TimeoutCommand.php
+++ b/src/Command/TimeoutCommand.php
@@ -136,9 +136,9 @@ final class TimeoutCommand extends Command
 
         $qb = $repository->createQueryBuilder('o');
         $qb
-            ->andWhere('o.processingState = :processingState')
+            ->andWhere('o.processingState IN (:processingStates)')
             ->andWhere('o.processingStateUpdatedAt <= :threshold')
-            ->setParameter('processingState', [ImageInterface::PROCESSING_STATE_PROCESSING])
+            ->setParameter('processingStates', [ImageInterface::PROCESSING_STATE_PENDING, ImageInterface::PROCESSING_STATE_PROCESSING])
             ->setParameter('threshold', new \DateTimeImmutable(sprintf('-%d min', $this->timeoutThreshold)))
             ->setMaxResults($maxResults)
         ;

--- a/src/EventSubscriber/ResetProcessingRetryStatusSubscriber.php
+++ b/src/EventSubscriber/ResetProcessingRetryStatusSubscriber.php
@@ -10,23 +10,24 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\Event;
 use Webmozart\Assert\Assert;
 
-final class ResetTriesSubscriber implements EventSubscriberInterface
+final class ResetProcessingRetryStatusSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {
         $event = sprintf('workflow.%s.completed.%s', ProcessWorkflow::NAME, ProcessWorkflow::TRANSITION_FINISH);
 
         return [
-            $event => 'resetTries',
+            $event => 'resetProcessingRetryStatus',
         ];
     }
 
-    public function resetTries(Event $event): void
+    public function resetProcessingRetryStatus(Event $event): void
     {
         /** @var ImageInterface|object $image */
         $image = $event->getSubject();
         Assert::isInstanceOf($image, ImageInterface::class);
 
         $image->resetProcessingTries();
+        $image->setProcessingRetryAt(null);
     }
 }

--- a/src/EventSubscriber/ResetTriesSubscriber.php
+++ b/src/EventSubscriber/ResetTriesSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusImagePlugin\EventSubscriber;
+
+use Setono\SyliusImagePlugin\Model\ImageInterface;
+use Setono\SyliusImagePlugin\Workflow\ProcessWorkflow;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Workflow\Event\Event;
+use Webmozart\Assert\Assert;
+
+final class ResetTriesSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        $event = sprintf('workflow.%s.completed.%s', ProcessWorkflow::NAME, ProcessWorkflow::TRANSITION_FINISH);
+
+        return [
+            $event => 'resetTries',
+        ];
+    }
+
+    public function resetTries(Event $event): void
+    {
+        /** @var ImageInterface|object $image */
+        $image = $event->getSubject();
+        Assert::isInstanceOf($image, ImageInterface::class);
+
+        $image->resetProcessingTries();
+    }
+}

--- a/src/Messenger/Middleware/EnsurePendingProcessingStateMiddleware.php
+++ b/src/Messenger/Middleware/EnsurePendingProcessingStateMiddleware.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusImagePlugin\Messenger\Middleware;
+
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\DoctrineObjectManagerTrait\ORM\ORMManagerTrait;
+use Setono\SyliusImagePlugin\Message\Command\ProcessImage;
+use Setono\SyliusImagePlugin\Model\ImageInterface;
+use Setono\SyliusImagePlugin\Workflow\ProcessWorkflow;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Workflow\Registry;
+use Webmozart\Assert\Assert;
+
+final class EnsurePendingProcessingStateMiddleware implements MiddlewareInterface
+{
+    use ORMManagerTrait;
+
+    private Registry $workflowRegistry;
+
+    public function __construct(ManagerRegistry $managerRegistry, Registry $workflowRegistry)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->workflowRegistry = $workflowRegistry;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $message = $envelope->getMessage();
+
+        // If the message already has an PendingProcessingStateEnsuredStamp we don't need to prepare/check the image
+        // This is the case when the message is received by the handler.
+        // Middleware handles the message both when sending and receiving.
+        // See https://symfony.com/doc/current/messenger.html#middleware
+        if ($message instanceof ProcessImage && null === $envelope->last(PendingProcessingStateEnsuredStamp::class)) {
+            $manager = $this->getManager($message->class);
+
+            $image = $manager->find($message->class, $message->imageId);
+            if ($image === null) {
+                // Something is clearly wrong. Don't pass the message along.
+                return $envelope;
+            }
+
+            Assert::isInstanceOf($image, ImageInterface::class);
+
+            $workflow = $this->workflowRegistry->get($image, ProcessWorkflow::NAME);
+
+            if (!$workflow->can($image, ProcessWorkflow::TRANSITION_ENQUEUE)) {
+                // Don't pass it down the line
+                return $envelope;
+            }
+
+            $workflow->apply($image, ProcessWorkflow::TRANSITION_ENQUEUE);
+
+            try {
+                $manager->flush();
+            } catch (OptimisticLockException $ex) {
+                // Don't pass it down the line
+                return $envelope;
+            }
+
+            $envelope = $envelope->with(new PendingProcessingStateEnsuredStamp());
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Messenger/Middleware/PendingProcessingStateEnsuredStamp.php
+++ b/src/Messenger/Middleware/PendingProcessingStateEnsuredStamp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusImagePlugin\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+final class PendingProcessingStateEnsuredStamp implements StampInterface
+{
+}

--- a/src/Model/ImageInterface.php
+++ b/src/Model/ImageInterface.php
@@ -29,6 +29,8 @@ interface ImageInterface extends BaseImageInterface
 
     public function incrementProcessingTries(int $increment = 1): void;
 
+    public function resetProcessingTries(): void;
+
     public function getProcessingRetryAt(): ?DateTimeInterface;
 
     public function setProcessingRetryAt(?DateTimeInterface $processingRetryAt): void;

--- a/src/Model/ImageInterface.php
+++ b/src/Model/ImageInterface.php
@@ -9,6 +9,8 @@ use Sylius\Component\Core\Model\ImageInterface as BaseImageInterface;
 
 interface ImageInterface extends BaseImageInterface
 {
+    public const PROCESSING_STATE_INITIAL = 'initial';
+
     public const PROCESSING_STATE_PENDING = 'pending';
 
     public const PROCESSING_STATE_PROCESSING = 'processing';

--- a/src/Model/ImageTrait.php
+++ b/src/Model/ImageTrait.php
@@ -15,8 +15,8 @@ trait ImageTrait
      */
     protected int $version = 1;
 
-    /** @ORM\Column(type="string", options={"default": ImageInterface::PROCESSING_STATE_PENDING}) */
-    protected string $processingState = ImageInterface::PROCESSING_STATE_PENDING;
+    /** @ORM\Column(type="string", options={"default": ImageInterface::PROCESSING_STATE_INITIAL}) */
+    protected string $processingState = ImageInterface::PROCESSING_STATE_INITIAL;
 
     /** @ORM\Column(type="datetime", nullable=true) */
     protected ?DateTimeInterface $processingStateUpdatedAt = null;

--- a/src/Model/ImageTrait.php
+++ b/src/Model/ImageTrait.php
@@ -66,6 +66,11 @@ trait ImageTrait
         $this->processingTries += $increment;
     }
 
+    public function resetProcessingTries(): void
+    {
+        $this->processingTries = 0;
+    }
+
     public function getProcessingRetryAt(): ?DateTimeInterface
     {
         return $this->processingRetryAt;

--- a/src/Resources/config/app/config.yaml
+++ b/src/Resources/config/app/config.yaml
@@ -11,7 +11,9 @@ framework:
                     Authorization: 'Bearer %env(CLOUDFLARE_API_TOKEN)%'
     messenger:
         buses:
-            setono_sylius_image.command_bus: ~
+            setono_sylius_image.command_bus:
+                middleware:
+                    - 'setono_sylius_image.messenger.middleware.ensure_pending_processing_state'
 
 knp_gaufrette:
     adapters:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,7 @@
         <import resource="services/controller.xml"/>
         <import resource="services/event_subscriber.xml"/>
         <import resource="services/message.xml"/>
+        <import resource="services/middleware.xml"/>
         <import resource="services/provider.xml"/>
         <import resource="services/registry.xml" />
         <import resource="services/synchronizer.xml"/>

--- a/src/Resources/config/services/event_subscriber.xml
+++ b/src/Resources/config/services/event_subscriber.xml
@@ -12,8 +12,8 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
-        <service id="setono_sylius_image.event_subscriber.reset_tries"
-                 class="Setono\SyliusImagePlugin\EventSubscriber\ResetTriesSubscriber">
+        <service id="setono_sylius_image.event_subscriber.reset_processing_retry_status"
+                 class="Setono\SyliusImagePlugin\EventSubscriber\ResetProcessingRetryStatusSubscriber">
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/src/Resources/config/services/event_subscriber.xml
+++ b/src/Resources/config/services/event_subscriber.xml
@@ -11,5 +11,10 @@
                  class="Setono\SyliusImagePlugin\EventSubscriber\UpdateRetryAtSubscriber">
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="setono_sylius_image.event_subscriber.reset_tries"
+                 class="Setono\SyliusImagePlugin\EventSubscriber\ResetTriesSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services/message.xml
+++ b/src/Resources/config/services/message.xml
@@ -22,7 +22,7 @@
                 </service>
             </argument>
 
-            <tag name="messenger.message_handler"/>
+            <tag name="messenger.message_handler" bus="setono_sylius_image.command_bus" />
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/middleware.xml
+++ b/src/Resources/config/services/middleware.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="setono_sylius_image.messenger.middleware.ensure_pending_processing_state"
+                 class="Setono\SyliusImagePlugin\Messenger\Middleware\EnsurePendingProcessingStateMiddleware">
+            <argument type="service" id="doctrine"/>
+            <argument type="service" id="workflow.registry"/>
+        </service>
+    </services>
+</container>

--- a/src/Workflow/ProcessWorkflow.php
+++ b/src/Workflow/ProcessWorkflow.php
@@ -15,6 +15,8 @@ final class ProcessWorkflow
 {
     public const NAME = 'setono_sylius_image__process';
 
+    public const TRANSITION_ENQUEUE = 'enqueue';
+
     public const TRANSITION_START = 'process';
 
     public const TRANSITION_FINISH = 'finish';
@@ -82,9 +84,10 @@ final class ProcessWorkflow
     public static function getTransitions(): array
     {
         return [
-            new Transition(self::TRANSITION_START, [ImageInterface::PROCESSING_STATE_PENDING, ImageInterface::PROCESSING_STATE_FAILED], ImageInterface::PROCESSING_STATE_PROCESSING),
+            new Transition(self::TRANSITION_ENQUEUE, [ImageInterface::PROCESSING_STATE_INITIAL, ImageInterface::PROCESSING_STATE_FAILED, ImageInterface::PROCESSING_STATE_PROCESSED], ImageInterface::PROCESSING_STATE_PENDING),
+            new Transition(self::TRANSITION_START, ImageInterface::PROCESSING_STATE_PENDING, ImageInterface::PROCESSING_STATE_PROCESSING),
             new Transition(self::TRANSITION_FINISH, ImageInterface::PROCESSING_STATE_PROCESSING, ImageInterface::PROCESSING_STATE_PROCESSED),
-            new Transition(self::TRANSITION_FAIL, ImageInterface::PROCESSING_STATE_PROCESSING, ImageInterface::PROCESSING_STATE_FAILED),
+            new Transition(self::TRANSITION_FAIL, [ImageInterface::PROCESSING_STATE_PENDING, ImageInterface::PROCESSING_STATE_PROCESSING], ImageInterface::PROCESSING_STATE_FAILED),
         ];
     }
 }

--- a/src/Workflow/ProcessWorkflow.php
+++ b/src/Workflow/ProcessWorkflow.php
@@ -31,6 +31,7 @@ final class ProcessWorkflow
     public static function getStates(): array
     {
         return [
+            ImageInterface::PROCESSING_STATE_INITIAL,
             ImageInterface::PROCESSING_STATE_PENDING,
             ImageInterface::PROCESSING_STATE_PROCESSING,
             ImageInterface::PROCESSING_STATE_PROCESSED,
@@ -56,7 +57,7 @@ final class ProcessWorkflow
                     'property' => 'processingState',
                 ],
                 'supports' => ImageInterface::class,
-                'initial_marking' => ImageInterface::PROCESSING_STATE_PENDING,
+                'initial_marking' => ImageInterface::PROCESSING_STATE_INITIAL,
                 'places' => self::getStates(),
                 'transitions' => $transitions,
             ],


### PR DESCRIPTION
Resolves #27 

- [x] Add a new processingState `initial` which will be the default value.
- [x] When images are added to queue it must transition into `pending` state (this indicates that it has been added to the queue)
- [x] It should be possible to move into the `pending` state from the following states `initial`, `processed`, `failed`
- [x] Add a lock to the `ProcessCommand`
- [x] `ProcessCommand` should look for images in one of the following states: `initial`, `processed`, `failed`
- [x] `TimeoutCommand` should look for images in one of the following states: `pending`, `processing`